### PR TITLE
(program.cpp) Add call to input_poll before input_state

### DIFF
--- a/bsnes/target-libretro/program.cpp
+++ b/bsnes/target-libretro/program.cpp
@@ -263,7 +263,10 @@ auto pollInputDevices(uint port, uint device, uint input) -> int16
 		default:
 			return 0;
 	}
-
+	
+	// This is costly but bsnes has no concept of input_state like in libretro
+	input_poll(); 
+	
 	return input_state(libretro_port, libretro_device, libretro_index, libretro_id);
 }
 


### PR DESCRIPTION
The libretro spec says the input_poll callback must be called at least once a frame. The problem is because this core was tested with RetroArch's default polling type. With the default type, "Late", the frontend itself ensures input_poll is called only once on the first input_state call. 

But, because this polling type also ignores the core's input_poll calls, RetroArch makes sure to call input_poll after running the core for 1 frame if input_state was never called, so as not to break the spec. And this masked the problem.