### PR TITLE
add subsystem support for SGB, states work, SRAM needs testing

### DIFF
--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -282,8 +282,8 @@ static void set_environment_info(retro_environment_t cb)
     };
 
     static const struct retro_subsystem_rom_info sgb_roms[] = {
-        { "Super Game Boy ROM", "smc|sfc|swc|fig|bs", true, false, true, sgb_memory, 1 },
         { "Game Boy ROM", "gb|gbc", true, false, true, gb_memory, 1 },
+        { "Super Game Boy ROM", "smc|sfc|swc|fig|bs", true, false, true, sgb_memory, 1 },
     };
 
     static const struct retro_subsystem_info subsystems[] = {
@@ -589,12 +589,10 @@ RETRO_API bool retro_load_game_special(unsigned game_type,
 	{
 		case RETRO_GAME_TYPE_SGB:
 		{
-			string sgb_full_path = string(info[0].path).transform("\\", "/");
-
-			libretro_print(RETRO_LOG_INFO, "SGB ROM: %s\n", info[0].path);
-			libretro_print(RETRO_LOG_INFO, "GB ROM: %s\n", info[1].path);
-			program->superFamicom.location = info[0].path;
-			program->gameBoy.location = info[1].path;
+			libretro_print(RETRO_LOG_INFO, "GB ROM: %s\n", info[0].path);
+			libretro_print(RETRO_LOG_INFO, "SGB ROM: %s\n", info[1].path);
+			program->gameBoy.location = info[0].path;
+			program->superFamicom.location = info[1].path;
 		}
 		break;
 		default:

--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -35,6 +35,10 @@ static string sgb_bios;
 #define RETRO_DEVICE_LIGHTGUN_JUSTIFIER    RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_LIGHTGUN, 1)
 #define RETRO_DEVICE_LIGHTGUN_JUSTIFIERS   RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_LIGHTGUN, 2)
 
+#define RETRO_GAME_TYPE_SGB             0x101 | 0x1000
+#define RETRO_MEMORY_SGB_SRAM ((1 << 8) | RETRO_MEMORY_SAVE_RAM)
+#define RETRO_MEMORY_GB_SRAM ((1 << 8) | RETRO_MEMORY_SAVE_RAM)
+
 static void flush_variables()
 {
 	retro_variable variable = { "bsnes_blur_emulation", nullptr };
@@ -268,9 +272,26 @@ static void set_controller_ports(unsigned port, unsigned device)
 
 static void set_environment_info(retro_environment_t cb)
 {
-	// TODO: Hook up RETRO_ENVIRONMENT_SET_SUBSYSTEM_INFO for Sufami/BSX/SGB?
-	// IIRC, no known frontend actually hooks it up properly, so doubt there is any
-	// real need for now.
+
+    static const struct retro_subsystem_memory_info sgb_memory[] = {
+        { "srm", RETRO_MEMORY_SGB_SRAM },
+    };
+
+    static const struct retro_subsystem_memory_info gb_memory[] = {
+        { "srm", RETRO_MEMORY_SGB_SRAM },
+    };
+
+    static const struct retro_subsystem_rom_info sgb_roms[] = {
+        { "Super Game Boy ROM", "smc|sfc|swc|fig|bs", true, false, true, sgb_memory, 1 },
+        { "Game Boy ROM", "gb|gbc", true, false, true, gb_memory, 1 },
+    };
+
+    static const struct retro_subsystem_info subsystems[] = {
+        { "Super Game Boy", "sgb", sgb_roms, 2, RETRO_GAME_TYPE_SGB },
+        {}
+    };
+
+	cb(RETRO_ENVIRONMENT_SET_SUBSYSTEM_INFO,  (void*)subsystems);
 
 	static const retro_controller_description port_1[] = {
 		{ "SNES Joypad", RETRO_DEVICE_JOYPAD },
@@ -449,7 +470,7 @@ RETRO_API void retro_get_system_info(retro_system_info *info)
 {
 	info->library_name     = "bsnes";
 	info->library_version  = Emulator::Version;
-	info->need_fullpath    = false;
+	info->need_fullpath    = true;
 	info->valid_extensions = "smc|sfc";
 	info->block_extract = false;
 }
@@ -554,7 +575,37 @@ RETRO_API bool retro_load_game(const retro_game_info *game)
 RETRO_API bool retro_load_game_special(unsigned game_type,
 		const struct retro_game_info *info, size_t num_info)
 {
-	return false;
+	// bsnes uses 0RGB1555 internally but it is deprecated
+	// let software conversion happen in frontend
+	/*retro_pixel_format fmt = RETRO_PIXEL_FORMAT_0RGB1555;
+	if (!environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &fmt))
+		return false;*/
+
+	emulator->configure("Audio/Frequency", SAMPLERATE);
+
+	flush_variables();
+
+	switch(game_type)
+	{
+		case RETRO_GAME_TYPE_SGB:
+		{
+			string sgb_full_path = string(info[0].path).transform("\\", "/");
+
+			libretro_print(RETRO_LOG_INFO, "SGB ROM: %s\n", info[0].path);
+			libretro_print(RETRO_LOG_INFO, "GB ROM: %s\n", info[1].path);
+			program->superFamicom.location = info[0].path;
+			program->gameBoy.location = info[1].path;
+		}
+		break;
+		default:
+			return false;
+	}
+
+	program->load();
+
+	emulator->connect(SuperFamicom::ID::Port::Controller1, SuperFamicom::ID::Device::Gamepad);
+	emulator->connect(SuperFamicom::ID::Port::Controller2, SuperFamicom::ID::Device::Gamepad);
+	return true;
 }
 
 RETRO_API void retro_unload_game()


### PR DESCRIPTION
This improves the weird loading situation with random files in folders, also allows loading from within archives

I figure people already know how to use it but I'll explain none-the-less
1. load the core
2. select load super gameboy, sublabel will tell you which content to load

![imagen](https://user-images.githubusercontent.com/1721040/67628955-884d3c00-f83c-11e9-9bb3-b9f2ba61383f.png)

If the rom is zipped use the browse archive option, load archive is broken (RA bug with subsystem, not the core)

3. select load super gameboy and select your SGB rom, can be zipped to, same caveats apply
4. select start super game boy

![imagen](https://user-images.githubusercontent.com/1721040/67628967-b9c60780-f83c-11e9-974a-7e5a5830ba1b.png)

Profit!

![imagen](https://user-images.githubusercontent.com/1721040/67628978-e24e0180-f83c-11e9-8679-de8c55612500.png)




