### PR TITLE
[Libretro] Fix MSU1 Support

### DIFF
--- a/bsnes/target-libretro/program.cpp
+++ b/bsnes/target-libretro/program.cpp
@@ -346,6 +346,17 @@ auto Program::openRomSuperFamicom(string name, vfs::file::mode mode) -> shared_p
 		return vfs::memory::file::open(superFamicom.expansion.data(), superFamicom.expansion.size());
 	}
 
+	if(name == "msu1/data.rom")
+	{
+		return vfs::fs::file::open({Location::notsuffix(superFamicom.location), ".msu"}, mode);
+	}
+
+	if(name.match("msu1/track*.pcm"))
+	{
+		name.trimLeft("msu1/track", 1L);
+		return vfs::fs::file::open({Location::notsuffix(superFamicom.location), name}, mode);
+	}
+
 	if(name == "save.ram")
 	{
 		string save_path;


### PR DESCRIPTION
This fixes MSU1 support, the handling was taken from bsnes\target-bsnes\program\game-rom.cpp +122
The PR was only tested against the bsnes-hd beta fork with my switch port, however it should just work.