### PR TITLE
Support SuperScope input for touchscreen devices (iOS, Android, Switch)

### DIFF
--- a/bsnes/sfc/controller/super-scope/super-scope.cpp
+++ b/bsnes/sfc/controller/super-scope/super-scope.cpp
@@ -93,7 +93,6 @@ auto SuperScope::latch() -> void {
   int nx = platform->inputPoll(port, ID::Device::SuperScope, X);
   int ny = platform->inputPoll(port, ID::Device::SuperScope, Y);
   bool relativeMode = configuration.input.pointer.relative;
-  printf("yoshi debug: sscope::latch relative=%i x=%i, nx=%i, y=%i, ny=%i\n",relativeMode,x,nx,y,ny);
   x = max(-16, min(256 + 16, relativeMode ? x + nx : nx ));
   y = max(-16, min((int)ppu.vdisp() + 16, relativeMode ? y + ny : ny));
   offscreen = (x < 0 || y < 0 || x >= 256 || y >= (int)ppu.vdisp());

--- a/bsnes/sfc/controller/super-scope/super-scope.cpp
+++ b/bsnes/sfc/controller/super-scope/super-scope.cpp
@@ -93,8 +93,9 @@ auto SuperScope::latch() -> void {
   int nx = platform->inputPoll(port, ID::Device::SuperScope, X);
   int ny = platform->inputPoll(port, ID::Device::SuperScope, Y);
   printf("yoshi debug: sscope::latch x=%i, nx=%i, y=%i, ny=%i\n",x,nx,y,ny);
-  x = max(-16, min(256 + 16, nx));
-  y = max(-16, min((int)ppu.vdisp() + 16, ny));
+  bool relativeMode = configuration.input.pointer.relative;
+  x = max(-16, min(256 + 16, relativeMode ? x + nx : nx ));
+  y = max(-16, min((int)ppu.vdisp() + 16, relativeMode ? y + ny : ny));
   offscreen = (x < 0 || y < 0 || x >= 256 || y >= (int)ppu.vdisp());
   if(!offscreen) ppu.latchCounters(x, y);
 }

--- a/bsnes/sfc/controller/super-scope/super-scope.cpp
+++ b/bsnes/sfc/controller/super-scope/super-scope.cpp
@@ -92,8 +92,8 @@ auto SuperScope::latch(bool data) -> void {
 auto SuperScope::latch() -> void {
   int nx = platform->inputPoll(port, ID::Device::SuperScope, X);
   int ny = platform->inputPoll(port, ID::Device::SuperScope, Y);
-  printf("yoshi debug: sscope::latch x=%i, nx=%i, y=%i, ny=%i\n",x,nx,y,ny);
   bool relativeMode = configuration.input.pointer.relative;
+  printf("yoshi debug: sscope::latch relative=%i x=%i, nx=%i, y=%i, ny=%i\n",relativeMode,x,nx,y,ny);
   x = max(-16, min(256 + 16, relativeMode ? x + nx : nx ));
   y = max(-16, min((int)ppu.vdisp() + 16, relativeMode ? y + ny : ny));
   offscreen = (x < 0 || y < 0 || x >= 256 || y >= (int)ppu.vdisp());

--- a/bsnes/sfc/controller/super-scope/super-scope.cpp
+++ b/bsnes/sfc/controller/super-scope/super-scope.cpp
@@ -92,8 +92,9 @@ auto SuperScope::latch(bool data) -> void {
 auto SuperScope::latch() -> void {
   int nx = platform->inputPoll(port, ID::Device::SuperScope, X);
   int ny = platform->inputPoll(port, ID::Device::SuperScope, Y);
-  x = max(-16, min(256 + 16, nx + x));
-  y = max(-16, min((int)ppu.vdisp() + 16, ny + y));
+  printf("yoshi debug: sscope::latch x=%i, nx=%i, y=%i, ny=%i\n",x,nx,y,ny);
+  x = max(-16, min(256 + 16, nx));
+  y = max(-16, min((int)ppu.vdisp() + 16, ny));
   offscreen = (x < 0 || y < 0 || x >= 256 || y >= (int)ppu.vdisp());
   if(!offscreen) ppu.latchCounters(x, y);
 }

--- a/bsnes/sfc/interface/configuration.cpp
+++ b/bsnes/sfc/interface/configuration.cpp
@@ -39,6 +39,8 @@ auto Configuration::process(Markup::Node document, bool load) -> void {
   bind(natural, "Hacks/SA1/Overclock", hacks.sa1.overclock);
   bind(natural, "Hacks/SuperFX/Overclock", hacks.superfx.overclock);
 
+  bind(boolean, "Input/Pointer/Relative", input.pointer.relative);
+  
   #undef bind
 }
 

--- a/bsnes/sfc/interface/configuration.hpp
+++ b/bsnes/sfc/interface/configuration.hpp
@@ -65,6 +65,12 @@ struct Configuration {
     } superfx;
   } hacks;
 
+  struct Input {
+    struct Pointer {
+      bool relative = false;
+    } pointer;
+  } input;
+
 private:
   auto process(Markup::Node document, bool load) -> void;
 };

--- a/bsnes/target-libretro/GNUmakefile
+++ b/bsnes/target-libretro/GNUmakefile
@@ -24,13 +24,7 @@ else ifeq ($(platform),windows)
 else ifeq ($(platform),macos)
 	$(strip $(compiler) -o out/$(name).dylib -shared $(objects) $(options))
 else ifeq ($(platform), ios-arm64)
-# ifeq ($(IOSSDK),)
-# 	IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
-# endif
 	$(strip c++ -arch arm64 -marm -miphoneos-version-min=11.0 -isysroot $(shell xcodebuild -version -sdk iphoneos Path) -o out/$(name)_ios.dylib -shared $(objects) -lpthread -ldl)
 else ifeq ($(platform), tvos-arm64)
-# ifeq ($(IOSSDK),)
-#   IOSSDK := $(shell xcodebuild -version -sdk appletvos Path)
-# endif
 	$(strip c++ -arch arm64 -marm -mtvos-version-min=11.0 -isysroot $(shell xcodebuild -version -sdk appletvos Path) -o out/$(name)_tvos.dylib -shared $(objects) -lpthread -ldl)
 endif

--- a/bsnes/target-libretro/GNUmakefile
+++ b/bsnes/target-libretro/GNUmakefile
@@ -24,13 +24,13 @@ else ifeq ($(platform),windows)
 else ifeq ($(platform),macos)
 	$(strip $(compiler) -o out/$(name).dylib -shared $(objects) $(options))
 else ifeq ($(platform), ios-arm64)
-    ifeq ($(IOSSDK),)
-       IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
-    endif
-	$(strip c++ -arch arm64 -marm -miphoneos-version-min=11.0 -isysroot $(IOSSDK) -o out/$(name)_ios.dylib -shared $(objects) -lpthread -ldl)
+# ifeq ($(IOSSDK),)
+# 	IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
+# endif
+	$(strip c++ -arch arm64 -marm -miphoneos-version-min=11.0 -isysroot $(shell xcodebuild -version -sdk iphoneos Path) -o out/$(name)_ios.dylib -shared $(objects) -lpthread -ldl)
 else ifeq ($(platform), tvos-arm64)
-    ifeq ($(IOSSDK),)
-       IOSSDK := $(shell xcodebuild -version -sdk appletvos Path)
-    endif
-	$(strip c++ -arch arm64 -marm -mtvos-version-min=11.0 -isysroot $(IOSSDK) -o out/$(name)_tvos.dylib -shared $(objects) -lpthread -ldl)
+# ifeq ($(IOSSDK),)
+#   IOSSDK := $(shell xcodebuild -version -sdk appletvos Path)
+# endif
+	$(strip c++ -arch arm64 -marm -mtvos-version-min=11.0 -isysroot $(shell xcodebuild -version -sdk appletvos Path) -o out/$(name)_tvos.dylib -shared $(objects) -lpthread -ldl)
 endif

--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -285,6 +285,21 @@ static void flush_variables()
 		else
 			run_ahead_frames = atoi(variable.value);
 	}
+
+	variable = { "bsnes_touchscreen_lightgun", nullptr };
+	if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &variable) && variable.value)
+	{
+		if (strcmp(variable.value, "ON") == 0)
+		{
+			emulator->configure("Input/Pointer/Relative", false);
+			retro_pointer_enabled = true;
+		}
+		else
+		{
+			emulator->configure("Input/Pointer/Relative", true);
+			retro_pointer_enabled = false;
+		}
+	}
 	
 	// Refresh Geometry
 	struct retro_system_av_info avinfo;
@@ -471,6 +486,7 @@ static void set_environment_info(retro_environment_t cb)
 		{ "bsnes_coprocessor_prefer_hle", "Coprocessor Prefer HLE; ON|OFF" },
 		{ "bsnes_sgb_bios", "Preferred Super GameBoy BIOS (restart); SGB1.sfc|SGB2.sfc" },
 		{ "bsnes_run_ahead_frames", "Amount of frames for run-ahead; OFF|1|2|3|4" },
+		{ "bsnes_touchscreen_lightgun", "Enable Touchscreen Lightgun; ON|OFF" },		
 		{ nullptr },
 	};
 	cb(RETRO_ENVIRONMENT_SET_VARIABLES, const_cast<retro_variable *>(vars));

--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -300,6 +300,19 @@ static void flush_variables()
 			retro_pointer_enabled = false;
 		}
 	}
+
+	variable = { "bsnes_touchscreen_lightgun_superscope_reverse", nullptr };
+	if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &variable) && variable.value)
+	{
+		if (strcmp(variable.value, "ON") == 0)
+		{
+			retro_pointer_superscope_reverse_buttons = true;
+		}
+		else
+		{
+			retro_pointer_superscope_reverse_buttons = false;
+		}
+	}
 	
 	// Refresh Geometry
 	struct retro_system_av_info avinfo;
@@ -486,7 +499,8 @@ static void set_environment_info(retro_environment_t cb)
 		{ "bsnes_coprocessor_prefer_hle", "Coprocessor Prefer HLE; ON|OFF" },
 		{ "bsnes_sgb_bios", "Preferred Super GameBoy BIOS (restart); SGB1.sfc|SGB2.sfc" },
 		{ "bsnes_run_ahead_frames", "Amount of frames for run-ahead; OFF|1|2|3|4" },
-		{ "bsnes_touchscreen_lightgun", "Enable Touchscreen Lightgun; ON|OFF" },		
+		{ "bsnes_touchscreen_lightgun", "Enable Touchscreen Lightgun; ON|OFF" },
+		{ "bsnes_touchscreen_lightgun_superscope_reverse", "Super Scope Reverse Trigger Buttons; OFF|ON" },
 		{ nullptr },
 	};
 	cb(RETRO_ENVIRONMENT_SET_VARIABLES, const_cast<retro_variable *>(vars));

--- a/bsnes/target-libretro/program.cpp
+++ b/bsnes/target-libretro/program.cpp
@@ -29,10 +29,6 @@ static const int POINTER_PRESSED_CYCLES = 4;
 static int pointer_cycles_after_released = 0;
 static int pointer_pressed_last_x = 0;
 static int pointer_pressed_last_y = 0;
-static int superscope_last_pressed_trigger = 0;
-static int superscope_last_pressed_cursor = 0;
-static int superscope_last_pressed_turbo = 0;
-static int superscope_last_pressed_paused = 0;
 
 struct retro_pointer_state
 {
@@ -145,6 +141,30 @@ static void input_update_pointer_lightgun( unsigned port, unsigned gun_device)
     }
 }
 
+static int input_handle_touchscreen_lightgun( unsigned port, unsigned gun_device, unsigned inputId)
+{
+	input_update_pointer_lightgun(port, gun_device);
+	printf("yoshi debug: x: %i, y: %i, trig: %i, curs: %i, turbo: %i, start: %i\n", retro_pointer.x, retro_pointer.y, retro_pointer.superscope_trigger_pressed, retro_pointer.superscope_cursor_pressed, retro_pointer.superscope_turbo_pressed, retro_pointer.superscope_start_pressed);
+	switch (inputId)
+	{
+		case 0: // X
+			return retro_pointer.x;
+		case 1: // Y
+			return retro_pointer.y;
+		case 2: // Trigger
+			// todo: reverse button setting
+			return retro_pointer.superscope_trigger_pressed ? 1 : 0;
+		case 3: // Cursor
+			return retro_pointer.superscope_cursor_pressed ? 1 : 0;
+		case 4: // Turbo
+			return retro_pointer.superscope_turbo_pressed ? 1 : 0;
+		case 5: // Pause
+			return retro_pointer.superscope_start_pressed ? 1 : 0;
+		default:
+			printf("Unknown input for super scope: %i \n",inputId);
+			return 0;
+	} 
+}
 
 struct Program : Emulator::Platform
 {
@@ -439,28 +459,9 @@ auto pollInputDevices(uint port, uint device, uint input) -> int16
 		// TODO: SuperScope/Justifiers.
 		// Do we care? The v94 port hasn't hooked them up. :)
 		case SuperFamicom::ID::Device::SuperScope:
-		{
 			libretro_device = RETRO_DEVICE_LIGHTGUN_SUPER_SCOPE;
-			input_update_pointer_lightgun(libretro_port, libretro_device);
-			printf("yoshi debug: x: %i, y: %i, trig: %i, curs: %i, turbo: %i, start: %i", retro_pointer.x, retro_pointer.y, retro_pointer.superscope_trigger_pressed, retro_pointer.superscope_cursor_pressed, retro_pointer.superscope_turbo_pressed, retro_pointer.superscope_start_pressed);
-			switch (input)
-			{
-				case 0: // X
-					return retro_pointer.x;
-				case 1: // Y
-					return retro_pointer.y;
-				case 2: // Trigger
-					// todo: reverse button setting
-					return retro_pointer.superscope_trigger_pressed ? 1 : 0;
-				case 3: // Turbo
-					return retro_pointer.superscope_turbo_pressed ? 1 : 0;
-				case 4: // Pause
-					return retro_pointer.superscope_start_pressed ? 1 : 0;
-				default:
-					printf("Unknown input for super scope!\n");
-			} 
+			return input_handle_touchscreen_lightgun(libretro_port, libretro_device, input);
 			break;
-		}
 
 		default:
 			return 0;

--- a/bsnes/target-libretro/program.cpp
+++ b/bsnes/target-libretro/program.cpp
@@ -41,7 +41,7 @@ struct retro_pointer_state
 };
 static retro_pointer_state retro_pointer = { 0, 0, false, false, false, false };
 static bool retro_pointer_enabled = false;
-
+static bool retro_pointer_superscope_reverse_buttons = false;
 static void input_update_pointer_lightgun( unsigned port, unsigned gun_device)
 {
 	int x, y;
@@ -109,25 +109,21 @@ static void input_update_pointer_lightgun( unsigned port, unsigned gun_device)
 							} else if ( touch_count == 3 ) {
 									turbo_pressed = true;
 							} else if ( touch_count == 2 ) {
-								// todo: handle reverse buttons setting
-								cursor_pressed = true;
-									// if ( setting_superscope_reverse_buttons )
-									// {
-									// 		trigger_pressed = true;
-									// } else
-									// {
-									// 		cursor_pressed = true;
-									// }
+								if ( retro_pointer_superscope_reverse_buttons )
+								{
+									trigger_pressed = true;
+								} else
+								{
+									cursor_pressed = true;
+								}
 							} else {
-								// todo: handle reverse buttons setting
-								trigger_pressed = true;
-									// if ( setting_superscope_reverse_buttons )
-									// {
-									// 		cursor_pressed = true;
-									// } else
-									// {
-									// 		trigger_pressed = true;
-									// }
+								if ( retro_pointer_superscope_reverse_buttons )
+								{
+									cursor_pressed = true;
+								} else
+								{
+									trigger_pressed = true;
+								}
 							}
 					}
 					retro_pointer.superscope_trigger_pressed = trigger_pressed;

--- a/bsnes/target-libretro/program.cpp
+++ b/bsnes/target-libretro/program.cpp
@@ -150,7 +150,6 @@ static int input_handle_touchscreen_lightgun( unsigned port, unsigned gun_device
 		case 1: // Y
 			return retro_pointer.y;
 		case 2: // Trigger
-			// todo: reverse button setting
 			return retro_pointer.superscope_trigger_pressed ? 1 : 0;
 		case 3: // Cursor
 			return retro_pointer.superscope_cursor_pressed ? 1 : 0;

--- a/bsnes/target-libretro/program.cpp
+++ b/bsnes/target-libretro/program.cpp
@@ -458,8 +458,9 @@ auto pollInputDevices(uint port, uint device, uint input) -> int16
 			if (retro_pointer_enabled)
 			{
 				return input_handle_touchscreen_lightgun(libretro_port, libretro_device, input);
+			} else {
+				return 0;
 			}
-			break;
 		}
 
 		default:

--- a/bsnes/target-libretro/program.cpp
+++ b/bsnes/target-libretro/program.cpp
@@ -86,7 +86,10 @@ static void input_update_pointer_lightgun( unsigned port, unsigned gun_device)
 			x = retro_pointer.pointer_pressed_last_x;
 			y = retro_pointer.pointer_pressed_last_y;
 			// unpress the primary trigger
-			retro_pointer.superscope_trigger_pressed = false;
+			if (retro_pointer_superscope_reverse_buttons)
+				retro_pointer.superscope_cursor_pressed = false;
+			else
+				retro_pointer.superscope_trigger_pressed = false;
 			return;
     }
 		retro_pointer.x = x;


### PR DESCRIPTION
Added support for SuperScope input for touchscreen devices. 

I altered the core bsnes code to support an absolute SuperScope pointer values for x and y and kept the relative mode intact by adding a new configuration option.

I can add support for other light guns like Justifier (and touchscreen via mouse?) but wanted to get this reviewed first. I'm not a c++ expert by any means.