### PR TITLE
Allow MSU-1 SGB games to work properly

### DIFF
--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -681,17 +681,42 @@ RETRO_API bool retro_load_game(const retro_game_info *game)
 
 	flush_variables();
 
-	if (string(game->path).endsWith(".gb") || string(game->path).endsWith(".gbc"))
+	if (string(game->path).endsWith(".gb"))
 	{
 		const char *system_dir;
 		environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir);
-		string sgb_full_path = string(system_dir, "/", sgb_bios).transform("\\", "/");
-		if (!file::exists(sgb_full_path)) {
+		string sgb_full_path = string(game->path).transform("\\", "/");
+		string sgb_full_path2 = string(sgb_full_path).replace(".gb", ".sfc");
+		if (!file::exists(sgb_full_path2)) {
+			string sgb_full_path = string(system_dir, "/", sgb_bios).transform("\\", "/");
+			program->superFamicom.location = sgb_full_path;
+		}
+        else {
+			program->superFamicom.location = sgb_full_path2;
+		}
+		program->gameBoy.location = string(game->path);
+		if (!file::exists(program->superFamicom.location)) {
+			return false;
+		}
+	}
+	else if (string(game->path).endsWith(".gbc"))
+	{
+		const char *system_dir;
+		environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir);
+		string sgb_full_path = string(game->path).transform("\\", "/");
+		string sgb_full_path2 = string(sgb_full_path).replace(".gbc", ".sfc");
+		if (!file::exists(sgb_full_path2)) {
+			string sgb_full_path = string(system_dir, "/", sgb_bios).transform("\\", "/");
+			program->superFamicom.location = sgb_full_path;
+		}
+        else {
+			program->superFamicom.location = sgb_full_path2;
+		}
+		program->gameBoy.location = string(game->path);
+		if (!file::exists(program->superFamicom.location)) {
 			return false;
 		}
 
-		program->superFamicom.location = sgb_full_path;
-		program->gameBoy.location = string(game->path);
 	}
 	else
 	{


### PR DESCRIPTION
This change allows for a SGB boot rom with the same name as a SGB rom to be loaded from the same folder, which allows for MSU-1 enhanced SGB games to work without having to rely on the subsystem menu.
If it fails to load a SGB boot rom from the same folder, it will revert to the already implemented method of loading the boot rom from the system directory and etc.