### PR TITLE
Fix build with gcc-13

### DIFF
--- a/nall/arithmetic/natural.hpp
+++ b/nall/arithmetic/natural.hpp
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 #define ConcatenateType(Size) uint##Size##_t
 #define DeclareType(Size) ConcatenateType(Size)
 


### PR DESCRIPTION
Error was:
In file included from ../nall/arithmetic.hpp:69:
../nall/arithmetic/natural.hpp: In function 'void nall::div(const uint4096_t&, const uint4096_t&, uint4096_t&, uint4096_t&)': ../nall/arithmetic/natural.hpp:239:23: error: 'runtime_error' is not a member of 'std'
  239 |   if(!rhs) throw std::runtime_error("division by zero");
      |                       ^~~~~~~~~~~~~
../nall/arithmetic/natural.hpp:239:23: note: 'std::runtime_error' is defined in header '<stdexcept>'; did you forget to '#include <stdexcept>'?