### PR TITLE
wdc65816: fix PLB wrapping in emulation mode

### DIFF
--- a/bsnes/processor/wdc65816/instructions-other.cpp
+++ b/bsnes/processor/wdc65816/instructions-other.cpp
@@ -205,9 +205,12 @@ E S.h = 0x01;
 auto WDC65816::instructionPullB() -> void {
   idle();
   idle();
-L B = pull();
+// looks like it reads from $200 and the official CPU manual got it wrong.
+// Reproduced and verified on real hardware via https://github.com/gilyon/snes-tests
+L B = pullN();
   ZF = B == 0;
   NF = B & 0x80;
+  E S.h = 0x01;
 }
 
 auto WDC65816::instructionPullP() -> void {


### PR DESCRIPTION
copied from asiekierka's commit to Ares here:
https://github.com/ares-emulator/ares/commit/e589f8d9cf1aaf04b1959bfc7d7085cb3861149c with an added comment for context. Since everywhere else got it wrong, including official CPU docs, it's likely to be contentious in the distant future.